### PR TITLE
Fix null pointer access in proxy_set

### DIFF
--- a/src/proxy.c
+++ b/src/proxy.c
@@ -126,7 +126,7 @@ int proxy_set(int uplink, const int downlinks[], size_t downlinks_cnt, enum prox
 {
 	struct proxy *proxy = NULL, *p;
 	list_for_each_entry(p, &proxies, head)
-		if (proxy->ifindex == uplink)
+		if (p->ifindex == uplink)
 			proxy = p;
 
 	if (proxy && (downlinks_cnt == 0 ||


### PR DESCRIPTION
We were checking `proxy->ifindex`, but `proxy` is initialized to NULL. Should be checking `p->ifindex` instead.

This fix was proposed by user @jajik in https://github.com/openwrt/omcproxy/issues/2 in 2017, but never adopted. I'm making a PR in hopes that it gets seen.