### PR TITLE
omcproxy: use syslog mask for logging level

### DIFF
--- a/src/omcproxy.c
+++ b/src/omcproxy.c
@@ -29,9 +29,6 @@
 #include "omcproxy.h"
 #include "proxy.h"
 
-int log_level = LOG_WARNING;
-
-
 enum {
 	PROXY_ATTR_SOURCE,
 	PROXY_ATTR_SCOPE,
@@ -128,7 +125,8 @@ int main(int argc, char **argv) {
 	signal(SIGTERM, handle_signal);
 	signal(SIGHUP, SIG_IGN);
 	signal(SIGPIPE, SIG_IGN);
-	openlog("omcproxy", LOG_PERROR, LOG_DAEMON);
+	openlog("omcproxy", LOG_PERROR | LOG_PID, LOG_DAEMON);
+	setlogmask(LOG_UPTO(L_LEVEL));
 
 	if (getuid()) {
 		L_ERR("must be run as root!");
@@ -147,8 +145,10 @@ int main(int argc, char **argv) {
 			usage(argv[0]);
 			return 1;
 		} else if (!strncmp(argv[i], "-v", 2)) {
+			int log_level;
 			if ((log_level = atoi(&argv[i][2])) <= 0)
-				log_level = 7;
+				log_level = LOG_DEBUG;
+			setlogmask(LOG_UPTO(log_level));
 			continue;
 		}
 

--- a/src/omcproxy.h
+++ b/src/omcproxy.h
@@ -20,16 +20,6 @@
 #ifndef OMGPROXY_H_
 #define OMGPROXY_H_
 
-#define OMGPROXY_DEFAULT_L_LEVEL 7
-
-#ifndef L_LEVEL
-#define L_LEVEL OMGPROXY_DEFAULT_L_LEVEL
-#endif /* !L_LEVEL */
-
-#ifndef L_PREFIX
-#define L_PREFIX ""
-#endif /* !L_PREFIX */
-
 #ifdef __APPLE__
 
 #define __APPLE_USE_RFC_3542
@@ -64,46 +54,18 @@ static inline omgp_time_t omgp_time(void) {
 			((omgp_time_t)ts.tv_nsec / (1000000000 / OMGP_TIME_PER_SECOND));
 }
 
-extern int log_level;
-
 // Logging macros
+#ifndef L_LEVEL
+#define L_LEVEL LOG_WARNING
+#endif /* !L_LEVEL */
 
-#define L_INTERNAL(level, ...)                  \
-do {                                            \
-  if (log_level >= level)                       \
-    syslog(level, L_PREFIX __VA_ARGS__);        \
- } while(0)
+#define L_INTERNAL(level, ...) syslog(level, __VA_ARGS__);
 
-#if L_LEVEL >= LOG_ERR
 #define L_ERR(...) L_INTERNAL(LOG_ERR, __VA_ARGS__)
-#else
-#define L_ERR(...) do {} while(0)
-#endif
-
-#if L_LEVEL >= LOG_WARNING
 #define L_WARN(...) L_INTERNAL(LOG_WARNING, __VA_ARGS__)
-#else
-#define L_WARN(...) do {} while(0)
-#endif
-
-#if L_LEVEL >= LOG_NOTICE
 #define L_NOTICE(...) L_INTERNAL(LOG_NOTICE, __VA_ARGS__)
-#else
-#define L_NOTICE(...) do {} while(0)
-#endif
-
-#if L_LEVEL >= LOG_INFO
 #define L_INFO(...) L_INTERNAL(LOG_INFO, __VA_ARGS__)
-#else
-#define L_INFO(...) do {} while(0)
-#endif
-
-#if L_LEVEL >= LOG_DEBUG
 #define L_DEBUG(...) L_INTERNAL(LOG_DEBUG, __VA_ARGS__)
-#else
-#define L_DEBUG(...) do {} while(0)
-#endif
-
 
 // Some C99 compatibility
 #ifndef typeof


### PR DESCRIPTION
Make use of syslog setlogmask() instead of handling logging level manually.
Fixes unused variable errors when L_LEVEL is set to < 7.