### PR TITLE
omcproxy: Update compiling instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ It is partly based on code of https://github.com/Oryon/pimbd
 
 ## Compiling
 
-omcproxy uses cmake:
-- To prepare a Makefile use:  "cmake ." 
-- To build / install use: "make" / "make install" afterwards.
-- To build DEB or RPM packages use: "make package" afterwards.
+The easiest way to compile omcproxy is by using `devel-build.sh` script within `sripts/` directory. Simply execute
+
+```bash
+./scripts/devel-build.sh
+```
+
+Note that `cmake` is required.
+


### PR DESCRIPTION
After recent changes (8957f6c2557b79d5ec49261de057ec3ba9c9f070, 49df5f5b870445f0cc0f4f9a88e5d06de1da669d) in the building process, the README is outdated.